### PR TITLE
changes to send problemId also with submissionId

### DIFF
--- a/SubmissionService/src/dtos/submission.dto.ts
+++ b/SubmissionService/src/dtos/submission.dto.ts
@@ -27,7 +27,8 @@ export interface UpdateSubmissionStatusRequestDTO {
 }
 
 export interface SubmissionQueueMessageDTO {
-	id: string;
+	problemId: string;
+	submissionId: string;
 	code: string;
 	lang: string;
 }

--- a/SubmissionService/src/services/submission.service.ts
+++ b/SubmissionService/src/services/submission.service.ts
@@ -22,7 +22,8 @@ export class SubmissionService {
 		const submission = await this.submissionRepository.createSubmission(submissionData);
 		this.logger.info(`Created submission: ${JSON.stringify(submission)}`);
 		await this.publisherService.publishSubmission(constantConfig.SUBMISSION_QUEUE, {
-			id: submission.id,
+			problemId: submission.problemId,
+			submissionId: submission.id,
 			code: submission.code,
 			lang: submission.lang,
 		});


### PR DESCRIPTION
This pull request updates how submission messages are structured and published to the submission queue, ensuring that both `problemId` and `submissionId` are included for better clarity and traceability. The changes impact both the data transfer object definition and the publishing logic.

**Submission message structure update:**

* Changed the `SubmissionQueueMessageDTO` interface in `submission.dto.ts` to replace the single `id` field with separate `problemId` and `submissionId` fields for more explicit identification of submissions.

**Publishing logic update:**

* Updated the `publishSubmission` call in `submission.service.ts` to send both `problemId` and `submissionId` (instead of just `id`) when publishing a submission to the queue, matching the new DTO structure.