### PR TITLE
New endpoint to download testcase

### DIFF
--- a/ProblemService/src/controllers/testcase.controller.ts
+++ b/ProblemService/src/controllers/testcase.controller.ts
@@ -37,6 +37,27 @@ class TestcaseController {
 			testcaseUrl,
 		});
 	};
+
+	downloadTestCaseFile = async (req: Request, res: Response) => {
+		const problemSlug = req.params.problemSlug as string;
+		const problem = await this.problemService.getProblemBySlug(problemSlug);
+		if (!problem) {
+			throw new NotFoundError(`Problem with slug '${problemSlug}' not found`);
+		}
+		if (!problem.testcaseUrl) {
+			throw new NotFoundError(`No test cases found for problem with slug '${problemSlug}'`);
+		}
+
+		logger.info("Starting testcase download process");
+		const { stream, contentType, fileName } = await this.testcaseService.downloadTestCaseFromS3(
+			problem.testcaseUrl
+		);
+		logger.info("Testcase download process completed successfully");
+
+		res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
+		res.setHeader("Content-Type", contentType);
+		stream.pipe(res);
+	};
 }
 
 const problemRepository = new ProblemRepository();

--- a/ProblemService/src/routers/v1/testcase.router.ts
+++ b/ProblemService/src/routers/v1/testcase.router.ts
@@ -9,3 +9,5 @@ testcaseRouter.post(
 	uploadTestcaseFileMiddleware,
 	testcaseController.uploadTestCaseFile
 );
+
+testcaseRouter.get("/download/:problemSlug", testcaseController.downloadTestCaseFile);

--- a/ProblemService/src/utils/helpers/extension.helpers.ts
+++ b/ProblemService/src/utils/helpers/extension.helpers.ts
@@ -1,0 +1,13 @@
+export const getFileExtension = (mimeType: string): string => {
+	switch (mimeType) {
+		case "application/json":
+			return ".json";
+		case "text/plain":
+			return ".txt";
+		case "application/xml":
+		case "text/xml":
+			return ".xml";
+		default:
+			return ".bin"; // fallback for unknown types
+	}
+};


### PR DESCRIPTION
This pull request adds support for downloading test case files for a problem from S3, including a new API endpoint and service method to handle the download process. It also introduces a helper for determining file extensions based on MIME type and ensures proper error handling and logging throughout the workflow.

**Test case download feature:**

* Added a new controller method `downloadTestCaseFile` in `testcase.controller.ts` to handle downloading test case files for a given `problemSlug`, including error handling for missing problems or test cases.
* Added a new API route `/download/:problemSlug` to `testcase.router.ts` to expose the test case download functionality.

**S3 integration and file handling:**

* Implemented `downloadTestCaseFromS3` in `testcase.service.ts`, which retrieves the test case file from S3 as a stream, determines the content type, and constructs the appropriate file name with extension.
* Added the `getFileExtension` helper to map MIME types to file extensions, ensuring downloaded files have the correct extension.

**Dependency updates:**

* Updated imports in `testcase.service.ts` to include `GetObjectCommand` from AWS SDK and the new extension helper.